### PR TITLE
Interface to set debug level for transactions

### DIFF
--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -149,6 +149,16 @@ func (w *WAF) NewTransactionWithID(id string) *Transaction {
 	return w.newTransactionWithID(id)
 }
 
+// Sachin Changes for enabling debug logging without reloading rules again
+// [[
+var transactionLoggingLevel int = 0
+
+func (w *WAF) SetTransactionDebugLevel(debugLevel int) {
+	transactionLoggingLevel = debugLevel
+}
+
+// ]]
+
 // NewTransactionWithID Creates a new initialized transaction for this WAF instance
 // Using the specified ID
 func (w *WAF) newTransactionWithID(id string) *Transaction {
@@ -177,6 +187,12 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 	tx.stopWatches = map[types.RulePhase]int64{}
 	tx.WAF = w
 	tx.debugLogger = w.Logger.With(debuglog.Str("tx_id", tx.id))
+	// Sachin Changes for enabling debug logging without reloading rules again
+	// [[
+	if transactionLoggingLevel > 0 {
+		tx.SetDebugLogLevel(debuglog.Level(transactionLoggingLevel))
+	}
+	// ]]
 	tx.Timestamp = time.Now().UnixNano()
 	tx.audit = false
 

--- a/waf.go
+++ b/waf.go
@@ -25,6 +25,11 @@ type WAF interface {
 	// MJ Change
 	WafGetRulesInfo(flagName string) interface{}
 	WafUpdateRuleFlags(flagName string, flagValue interface{}) bool
+
+	// Sachin Changes for enabling debug logging without reloading rules again
+	// [[
+	SetTransactionDebugLevel(debugLevel int)
+	// ]]
 }
 
 // NewWAF creates a new WAF instance with the provided configuration.
@@ -131,6 +136,14 @@ func (w wafWrapper) NewTransactionWithID(id string) types.Transaction {
 func (w wafWrapper) WafGetRulesInfo(flagName string) interface{} {
 	return corazawaf.GetRuleTimingsRecord() //only 1 supported as of now
 }
+
+// Sachin Changes for enabling debug logging without reloading rules again
+// [[
+func (w wafWrapper) SetTransactionDebugLevel(debugLevel int) {
+	w.waf.SetTransactionDebugLevel(debugLevel)
+}
+
+// ]]
 
 func (w wafWrapper) WafUpdateRuleFlags(flagName string, flagValue interface{}) bool {
 	ret_val := false


### PR DESCRIPTION
Store transactionLoggingLevel in global and set it via rest api in dp to enable debug logging on console for coraza.

Issue: https://github.com/appsentinels/test/issues/8860